### PR TITLE
Fixup with dependency declarations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,8 @@ package_dir =
     =src
 packages = find:
 python_requires = >=3.6
-install_requires = [
-    'matplotlib'
-]
+install_requires =
+    matplotlib
 
 [options.packages.find]
 where=src

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist = py36, py37
+skip_missing_interpreters = true
 
 [testenv]
 deps =
     pytest
-    matplotlib
-    
 commands = pytest


### PR DESCRIPTION
Tox should be testing without installing matplotlib, and setup.cfg had a syntax error.